### PR TITLE
Add Onshape Connector module scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/onshape_connector/__manifest__.py
+++ b/onshape_connector/__manifest__.py
@@ -1,0 +1,7 @@
+{
+    "name": "Onshape Connector",
+    "version": "1.0",
+    "depends": ["base"],
+    "data": [],
+    "installable": True,
+}


### PR DESCRIPTION
## Summary
- create basic `onshape_connector` addon scaffold with metadata
- add empty `controllers` and `models` directories for future code
- ignore compiled Python files

## Testing
- `python -m py_compile onshape_connector/__init__.py onshape_connector/__manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a445d30a288330aaf1a66ab7a56a33