### PR TITLE
Add manual route and scheduled Onshape document synchronization

### DIFF
--- a/onshape_connector/__init__.py
+++ b/onshape_connector/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/onshape_connector/__manifest__.py
+++ b/onshape_connector/__manifest__.py
@@ -2,6 +2,6 @@
     "name": "Onshape Connector",
     "version": "1.0",
     "depends": ["base"],
-    "data": [],
+    "data": ["data/ir_cron.xml"],
     "installable": True,
 }

--- a/onshape_connector/controllers/__init__.py
+++ b/onshape_connector/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/onshape_connector/controllers/main.py
+++ b/onshape_connector/controllers/main.py
@@ -1,0 +1,13 @@
+from odoo import http
+from odoo.http import request
+
+
+class OnshapeSyncController(http.Controller):
+    """Controller providing an endpoint to manually trigger Onshape sync."""
+
+    @http.route("/onshape/sync", type="json", auth="user")
+    def manual_sync(self):
+        """Manually trigger synchronization of all Onshape documents."""
+        docs = request.env["onshape.document"].sudo()
+        docs.cron_sync_documents()
+        return {"status": "ok"}

--- a/onshape_connector/data/ir_cron.xml
+++ b/onshape_connector/data/ir_cron.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_onshape_sync" model="ir.cron">
+            <field name="name">Onshape Document Sync</field>
+            <field name="model_id" ref="onshape_connector.model_onshape_document"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_sync_documents()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/onshape_connector/models/__init__.py
+++ b/onshape_connector/models/__init__.py
@@ -1,0 +1,1 @@
+from . import onshape_document

--- a/onshape_connector/models/onshape_document.py
+++ b/onshape_connector/models/onshape_document.py
@@ -1,0 +1,36 @@
+"""Odoo model representing an Onshape document."""
+
+from odoo import api, fields, models
+
+from models.onshape_client import OnshapeClient
+from models.onshape_document import OnshapeDocument as DocumentData
+
+
+class OnshapeDocument(models.Model):
+    """Persisted Onshape document in Odoo."""
+
+    _name = "onshape.document"
+    _description = "Onshape Document"
+
+    name = fields.Char(required=True)
+    onshape_id = fields.Char(required=True)
+    last_sync = fields.Datetime()
+
+    def action_sync(self):
+        """Synchronize this document with Onshape."""
+        client = OnshapeClient()
+        for record in self:
+            data = DocumentData.fetch(client, record.onshape_id)
+            record.write(
+                {
+                    "name": data.name,
+                    "last_sync": fields.Datetime.now(),
+                }
+            )
+
+    @api.model
+    def cron_sync_documents(self):
+        """Cron job to synchronize all documents."""
+        docs = self.search([])
+        docs.action_sync()
+        return True

--- a/tests/test_onshape_document.py
+++ b/tests/test_onshape_document.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.onshape_document import OnshapeDocument
+
+
+class FakeClient:
+    def __init__(self):
+        self.updated = False
+
+    def get_document(self, document_id: str) -> dict:
+        return {"name": f"Doc {document_id}"}
+
+    def update_document(self, document_id: str, payload: dict):
+        self.updated = True
+        return {"ok": True}
+
+
+def test_fetch_and_sync():
+    client = FakeClient()
+    doc = OnshapeDocument.fetch(client, "123")
+    assert doc.name == "Doc 123"
+    last_sync = doc.last_sync
+    doc.sync(client)
+    assert doc.last_sync > last_sync
+
+
+def test_update_document():
+    client = FakeClient()
+    doc = OnshapeDocument(name="Initial", onshape_id="1", last_sync=None)
+    doc.name = "Updated"
+    result = doc.update(client)
+    assert client.updated
+    assert result["ok"]


### PR DESCRIPTION
## Summary
- add HTTP controller `/onshape/sync` for manual document sync
- create Odoo model and cron job to synchronize Onshape documents automatically
- include unit tests for document synchronization logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a449be9ac08330869e71d67b4db321