### PR TITLE
Fix missing imports in Onshape connector

### DIFF
--- a/onshape_connector/models/onshape_client.py
+++ b/onshape_connector/models/onshape_client.py
@@ -1,0 +1,93 @@
+import base64
+import hmac
+import os
+import uuid
+from email.utils import formatdate
+from hashlib import sha256
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class OnshapeClient:
+    """Simple client for interacting with the Onshape API.
+
+    The client uses HMAC-SHA256 signatures as documented by Onshape to
+    authenticate every request. API keys are loaded from environment
+    variables ``ONSHAPE_ACCESS_KEY`` and ``ONSHAPE_SECRET_KEY`` unless
+    explicitly provided.
+    """
+
+    def __init__(
+        self,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self.access_key = access_key or os.getenv("ONSHAPE_ACCESS_KEY")
+        self.secret_key = secret_key or os.getenv("ONSHAPE_SECRET_KEY")
+        if not self.access_key or not self.secret_key:
+            raise ValueError("Onshape API keys not provided.")
+
+        self.base_url = base_url or os.getenv(
+            "ONSHAPE_BASE_URL", "https://cad.onshape.com/api"
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_signature(
+        self, method: str, path: str, query: str = "", content_type: str = ""
+    ) -> Dict[str, str]:
+        """Create authorization headers for a request."""
+        nonce = uuid.uuid4().hex
+        date = formatdate(timeval=None, usegmt=True)
+        canonical = "\n".join([method.upper(), nonce, date, path, query])
+        digest = hmac.new(
+            self.secret_key.encode("utf-8"), canonical.encode("utf-8"), sha256
+        ).digest()
+        signature = base64.b64encode(digest).decode("utf-8")
+
+        headers = {
+            "Date": date,
+            "On-Nonce": nonce,
+            "Authorization": f"On {self.access_key}:{signature}",
+        }
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, str]] = None,
+        content_type: str = "",
+    ) -> Any:
+        """Perform an HTTP request against the Onshape API."""
+        query = ""
+        if params:
+            # Sort parameters for canonical query string
+            query = "&".join(
+                f"{k}={v}" for k, v in sorted(params.items()) if v is not None
+            )
+        headers = self._build_signature(method, path, query, content_type)
+        url = f"{self.base_url}{path}"
+        response = requests.request(
+            method, url, params=params, headers=headers, timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_document(self, document_id: str) -> Any:
+        """Retrieve a document description."""
+        path = f"/documents/{document_id}"
+        return self._request("GET", path)
+
+    def get_part(self, studio_id: str, element_id: str) -> Any:
+        """Retrieve part information from a Part Studio element."""
+        path = f"/partstudios/d/{studio_id}/e/{element_id}"
+        return self._request("GET", path)

--- a/onshape_connector/models/onshape_document.py
+++ b/onshape_connector/models/onshape_document.py
@@ -2,8 +2,8 @@
 
 from odoo import api, fields, models
 
-from models.onshape_client import OnshapeClient
-from models.onshape_document import OnshapeDocument as DocumentData
+from .onshape_client import OnshapeClient
+from .onshape_document_data import OnshapeDocumentData
 
 
 class OnshapeDocument(models.Model):
@@ -20,7 +20,7 @@ class OnshapeDocument(models.Model):
         """Synchronize this document with Onshape."""
         client = OnshapeClient()
         for record in self:
-            data = DocumentData.fetch(client, record.onshape_id)
+            data = OnshapeDocumentData.fetch(client, record.onshape_id)
             record.write(
                 {
                     "name": data.name,

--- a/onshape_connector/models/onshape_document_data.py
+++ b/onshape_connector/models/onshape_document_data.py
@@ -1,0 +1,65 @@
+"""Onshape document model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import ClassVar, Optional, Protocol, Any
+
+
+class OnshapeClientProtocol(Protocol):
+    """Protocol describing the minimal interface used by :class:`OnshapeDocument`."""
+
+    def get_document(self, document_id: str) -> dict:
+        """Retrieve a document by its identifier."""
+
+    def update_document(self, document_id: str, payload: dict) -> Any:
+        """Update a document with the given payload."""
+
+
+@dataclass
+class OnshapeDocumentData:
+    """Representation of an Onshape document.
+
+    Attributes:
+        name: Human readable name of the document.
+        onshape_id: Unique identifier of the document in Onshape.
+        last_sync: Timestamp of the most recent synchronization with Onshape.
+    """
+
+    MODEL_NAME: ClassVar[str] = "onshape.document"
+
+    name: str
+    onshape_id: str
+    last_sync: Optional[datetime] = None
+
+    @classmethod
+    def fetch(cls, client: OnshapeClientProtocol, document_id: str) -> "OnshapeDocumentData":
+        """Fetch a document from Onshape using the provided client.
+
+        Args:
+            client: Instance capable of communicating with Onshape.
+            document_id: The Onshape identifier of the document to fetch.
+
+        Returns:
+            An instance of :class:`OnshapeDocument` populated with data from Onshape.
+        """
+        data = client.get_document(document_id)
+        return cls(
+            name=data.get("name", ""),
+            onshape_id=document_id,
+            last_sync=datetime.utcnow(),
+        )
+
+    def sync(self, client: OnshapeClientProtocol) -> None:
+        """Refresh this document's information from Onshape."""
+        data = client.get_document(self.onshape_id)
+        self.name = data.get("name", self.name)
+        self.last_sync = datetime.utcnow()
+
+    def update(self, client: OnshapeClientProtocol) -> Any:
+        """Push local changes of this document to Onshape."""
+        payload = {"name": self.name}
+        result = client.update_document(self.onshape_id, payload)
+        self.last_sync = datetime.utcnow()
+        return result


### PR DESCRIPTION
## Summary
- include client and dataclass within addon
- use relative imports in onshape document model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a442c5f5248330ac316bb1174c2c6f