### PR TITLE
Add minimal Onshape connector for Odoo 18

### DIFF
--- a/onshape_connector/__init__.py
+++ b/onshape_connector/__init__.py
@@ -1,0 +1,1 @@
+from . import models, controllers

--- a/onshape_connector/__manifest__.py
+++ b/onshape_connector/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Onshape Connector",
+    "version": "18.0.1.0.0",
+    "summary": "Sehr einfache Verbindung zu Onshape",
+    "depends": ["base"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/onshape_document_views.xml"
+    ],
+    "license": "LGPL-3",
+    "application": False,
+}

--- a/onshape_connector/controllers/__init__.py
+++ b/onshape_connector/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import onshape_controller

--- a/onshape_connector/controllers/onshape_controller.py
+++ b/onshape_connector/controllers/onshape_controller.py
@@ -1,0 +1,9 @@
+"""HTTP-Controller für die Synchronisation."""
+from odoo import http
+
+
+class OnshapeController(http.Controller):
+    @http.route("/onshape/sync", type="http", auth="user", csrf=False)
+    def sync_onshape(self):
+        http.request.env["onshape.document"].sudo().fetch_documents()
+        return http.Response("Synchronisation abgeschlossen", status=200)

--- a/onshape_connector/models/__init__.py
+++ b/onshape_connector/models/__init__.py
@@ -1,0 +1,1 @@
+from . import onshape_document

--- a/onshape_connector/models/onshape_document.py
+++ b/onshape_connector/models/onshape_document.py
@@ -1,0 +1,45 @@
+"""Minimaler Onshape-Dokument-Connector."""
+import base64
+import hashlib
+import hmac
+import time
+
+import requests
+from odoo import api, fields, models
+
+
+class OnshapeDocument(models.Model):
+    """Speichert Dokument-Infos aus Onshape."""
+
+    _name = "onshape.document"
+    _description = "Onshape Dokument"
+
+    name = fields.Char(required=True)
+    document_id = fields.Char(required=True)
+
+    @api.model
+    def _get_credentials(self):
+        """Liest API-Schlüssel aus den Systemparametern."""
+        params = self.env["ir.config_parameter"].sudo()
+        api_key = params.get_param("onshape.api_key")
+        api_secret = params.get_param("onshape.api_secret")
+        if not api_key or not api_secret:
+            raise ValueError("Onshape API Key/Secret nicht gesetzt")
+        return api_key, api_secret
+
+    @api.model
+    def fetch_documents(self):
+        """Lädt Dokumente aus Onshape und speichert sie."""
+        api_key, api_secret = self._get_credentials()
+        base_url = "https://cad.onshape.com"
+        endpoint = "/api/documents"
+        method = "GET"
+        date = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime())
+        signature_string = f"{method}\n{date}\n{endpoint}\n".encode()
+        digest = hmac.new(api_secret.encode(), signature_string, hashlib.sha256).digest()
+        signature = base64.b64encode(digest).decode()
+        headers = {"Date": date, "Authorization": f"On {api_key}:{signature}"}
+        response = requests.get(base_url + endpoint, headers=headers, timeout=10)
+        response.raise_for_status()
+        for doc in response.json().get("items", []):
+            self.create({"name": doc["name"], "document_id": doc["id"]})

--- a/onshape_connector/security/ir.model.access.csv
+++ b/onshape_connector/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_onshape_document,onshape.document,model_onshape_document,base.group_user,1,1,1,1

--- a/onshape_connector/views/onshape_document_views.xml
+++ b/onshape_connector/views/onshape_document_views.xml
@@ -1,0 +1,23 @@
+<odoo>
+  <record id="view_onshape_document_list" model="ir.ui.view">
+    <field name="name">onshape.document.list</field>
+    <field name="model">onshape.document</field>
+    <field name="arch" type="xml">
+      <list>
+        <field name="name"/>
+        <field name="document_id"/>
+      </list>
+    </field>
+  </record>
+
+  <record id="action_onshape_documents" model="ir.actions.act_window">
+    <field name="name">Onshape Dokumente</field>
+    <field name="res_model">onshape.document</field>
+    <field name="view_mode">list</field>
+  </record>
+
+  <menuitem id="menu_onshape_root" name="Onshape"/>
+  <menuitem id="menu_onshape_docs" name="Dokumente"
+            parent="menu_onshape_root"
+            action="action_onshape_documents"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add minimal Odoo 18 module for fetching documents from Onshape
- expose HTTP route to trigger document sync
- provide basic list view and access control

## Testing
- `python -m py_compile onshape_connector/__init__.py onshape_connector/models/__init__.py onshape_connector/models/onshape_document.py onshape_connector/controllers/__init__.py onshape_connector/controllers/onshape_controller.py`
- `xmllint --noout onshape_connector/views/onshape_document_views.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a46c3e9f3c8330bdebf69141877adc